### PR TITLE
Partially redacted authorization

### DIFF
--- a/examples/CopyProfiles.json
+++ b/examples/CopyProfiles.json
@@ -139,93 +139,93 @@
     } ]
   }
 }, {
-	"name" : "Default - Truncate Response",
-	"updateRequestContentLength" : false,
-	"updateResponseContentLength" : false,
-	"requestRules" : {
-	  "data" : [ {
-		"enabled" : true,
-		"location" : 7,
-		"match" : "^Sec-(.*)",
-		"replace" : "",
-		"regex" : true,
-		"caseSensitive" : false,
-		"comment" : "Removes headers that start with Sec-"
-	  }, {
-		"enabled" : true,
-		"location" : 7,
-		"match" : "^Accept-(Language|Encoding).*",
-		"replace" : "",
-		"regex" : true,
-		"caseSensitive" : false,
-		"comment" : "Removes headers that start with Accept-Language|Encoding"
-	  }, {
-		"enabled" : true,
-		"location" : 6,
-		"match" : "^Cookie:.*",
-		"replace" : "Cookie: [...TRUNCATED...]",
-		"regex" : true,
-		"caseSensitive" : false,
-		"comment" : "Truncates all cookies."
-	  }, {
-		"enabled" : true,
-		"location" : 6,
-		"match" : "^Authorization: Bearer ([^\\n]+)",
-		"replace" : "Authorization: Bearer [...REDACTED...]",
-		"regex" : true,
-		"caseSensitive" : false,
-		"comment" : "Redact Bearer Token"
-	  } ]
-	},
-	"responseRules" : {
-	  "data" : [ {
-		"enabled" : true,
-		"location" : 3,
-		"match" : "^Set-Cookie:.*",
-		"replace" : "Set-Cookie: [...TRUNCATED...]",
-		"regex" : true,
-		"caseSensitive" : false,
-		"comment" : "Truncates all cookies."
-	  }, {
-		"enabled" : true,
-		"location" : 4,
-		"match" : "^Server-.*",
-		"replace" : "",
-		"regex" : true,
-		"caseSensitive" : false,
-		"comment" : ""
-	  }, {
-		"enabled" : true,
-		"location" : 4,
-		"match" : "Accept-CH",
-		"replace" : "",
-		"regex" : false,
-		"caseSensitive" : false,
-		"comment" : ""
-	  }, {
-		"enabled" : true,
-		"location" : 4,
-		"match" : "^x-azure.*",
-		"replace" : "",
-		"regex" : true,
-		"caseSensitive" : false,
-		"comment" : ""
-	  }, {
-		"enabled" : true,
-		"location" : 2,
-		"match" : "(Set\\-Cookie: \\[\\.\\.\\.TRUNCATED\\.\\.\\.\\]([\\r\\n]*))+",
-		"replace" : "Set-Cookie: [...TRUNCATED...]$2",
-		"regex" : true,
-		"caseSensitive" : false,
-		"comment" : "Remove duplicated Set-Cookie headers."
-	  }, {
-		"enabled" : true,
-		"location" : 6,
-		"match" : "^(.{0,200}).*$",
-		"replace" : "$1[...TRUNCATED...]",
-		"regex" : true,
-		"caseSensitive" : false,
-		"comment" : "Truncate Long Responses"
-	  } ]
-	}
-  } ]
+  "name" : "Default - Truncate Response",
+  "updateRequestContentLength" : false,
+  "updateResponseContentLength" : false,
+  "requestRules" : {
+    "data" : [ {
+      "enabled" : true,
+      "location" : 7,
+      "match" : "^Sec-(.*)",
+      "replace" : "",
+      "regex" : true,
+      "caseSensitive" : false,
+      "comment" : "Removes headers that start with Sec-"
+    }, {
+      "enabled" : true,
+      "location" : 7,
+      "match" : "^Accept-(Language|Encoding).*",
+      "replace" : "",
+      "regex" : true,
+      "caseSensitive" : false,
+      "comment" : "Removes headers that start with Accept-Language|Encoding"
+    }, {
+      "enabled" : true,
+      "location" : 6,
+      "match" : "^Cookie:.*",
+      "replace" : "Cookie: [...TRUNCATED...]",
+      "regex" : true,
+      "caseSensitive" : false,
+      "comment" : "Truncates all cookies."
+    }, {
+      "enabled" : true,
+      "location" : 6,
+      "match" : "^Authorization: Bearer ([^\\n]+)",
+      "replace" : "Authorization: Bearer [...REDACTED...]",
+      "regex" : true,
+      "caseSensitive" : false,
+      "comment" : "Redact Bearer Token"
+    } ]
+  },
+  "responseRules" : {
+    "data" : [ {
+      "enabled" : true,
+      "location" : 3,
+      "match" : "^Set-Cookie:.*",
+      "replace" : "Set-Cookie: [...TRUNCATED...]",
+      "regex" : true,
+      "caseSensitive" : false,
+      "comment" : "Truncates all cookies."
+    }, {
+      "enabled" : true,
+      "location" : 4,
+      "match" : "^Server-.*",
+      "replace" : "",
+      "regex" : true,
+      "caseSensitive" : false,
+      "comment" : ""
+    }, {
+      "enabled" : true,
+      "location" : 4,
+      "match" : "Accept-CH",
+      "replace" : "",
+      "regex" : false,
+      "caseSensitive" : false,
+      "comment" : ""
+    }, {
+      "enabled" : true,
+      "location" : 4,
+      "match" : "^x-azure.*",
+      "replace" : "",
+      "regex" : true,
+      "caseSensitive" : false,
+      "comment" : ""
+    }, {
+      "enabled" : true,
+      "location" : 2,
+      "match" : "(Set\\-Cookie: \\[\\.\\.\\.TRUNCATED\\.\\.\\.\\]([\\r\\n]*))+",
+      "replace" : "Set-Cookie: [...TRUNCATED...]$2",
+      "regex" : true,
+      "caseSensitive" : false,
+      "comment" : "Remove duplicated Set-Cookie headers."
+    }, {
+      "enabled" : true,
+      "location" : 6,
+      "match" : "^(.{0,200}).*$",
+      "replace" : "$1[...TRUNCATED...]",
+      "regex" : true,
+      "caseSensitive" : false,
+      "comment" : "Truncate Long Responses"
+    } ]
+  }
+} ]

--- a/examples/CopyProfiles.json
+++ b/examples/CopyProfiles.json
@@ -228,4 +228,94 @@
       "comment" : "Truncate Long Responses"
     } ]
   }
+}, {
+  "name" : "Default - Partially Redacted - Truncate Response",
+  "updateRequestContentLength" : false,
+  "updateResponseContentLength" : false,
+  "requestRules" : {
+    "data" : [ {
+      "enabled" : true,
+      "location" : 7,
+      "match" : "^Sec-(.*)",
+      "replace" : "",
+      "regex" : true,
+      "caseSensitive" : false,
+      "comment" : "Removes headers that start with Sec-"
+    }, {
+      "enabled" : true,
+      "location" : 7,
+      "match" : "^Accept-(Language|Encoding).*",
+      "replace" : "",
+      "regex" : true,
+      "caseSensitive" : false,
+      "comment" : "Removes headers that start with Accept-Language|Encoding"
+    }, {
+      "enabled" : true,
+      "location" : 6,
+      "match" : "^Cookie:.*",
+      "replace" : "Cookie: [...TRUNCATED...]",
+      "regex" : true,
+      "caseSensitive" : false,
+      "comment" : "Truncates all cookies."
+    }, {
+      "enabled" : true,
+      "location" : 6,
+      "match" : "^Authorization: (Bearer|Basic) ([^\\n]{1})([^\\n]+)([^\\n]{1})",
+      "replace" : "Authorization: $1 $2[...REDACTED...]$4",
+      "regex" : true,
+      "caseSensitive" : false,
+      "comment" : "Partially Redacted Bearer or Basic Token (modify {1} to adjust number of chars before/after redacting) e.g. \"x[...REDACTED...]x\""
+    } ]
+  },
+  "responseRules" : {
+    "data" : [ {
+      "enabled" : true,
+      "location" : 3,
+      "match" : "^Set-Cookie:.*",
+      "replace" : "Set-Cookie: [...TRUNCATED...]",
+      "regex" : true,
+      "caseSensitive" : false,
+      "comment" : "Truncates all cookies."
+    }, {
+      "enabled" : true,
+      "location" : 4,
+      "match" : "^Server-.*",
+      "replace" : "",
+      "regex" : true,
+      "caseSensitive" : false,
+      "comment" : ""
+    }, {
+      "enabled" : true,
+      "location" : 4,
+      "match" : "Accept-CH",
+      "replace" : "",
+      "regex" : false,
+      "caseSensitive" : false,
+      "comment" : ""
+    }, {
+      "enabled" : true,
+      "location" : 4,
+      "match" : "^x-azure.*",
+      "replace" : "",
+      "regex" : true,
+      "caseSensitive" : false,
+      "comment" : ""
+    }, {
+      "enabled" : true,
+      "location" : 2,
+      "match" : "(Set\\-Cookie: \\[\\.\\.\\.TRUNCATED\\.\\.\\.\\]([\\r\\n]*))+",
+      "replace" : "Set-Cookie: [...TRUNCATED...]$2",
+      "regex" : true,
+      "caseSensitive" : false,
+      "comment" : "Remove duplicated Set-Cookie headers."
+    }, {
+      "enabled" : true,
+      "location" : 6,
+      "match" : "^(.{0,200}).*$",
+      "replace" : "$1[...TRUNCATED...]",
+      "regex" : true,
+      "caseSensitive" : false,
+      "comment" : "Truncate Long Responses"
+    } ]
+  }
 } ]


### PR DESCRIPTION
1x fix + 1x new sample profile:

1. Fix indention from Burp export
2. Added example profile to partially redact Authorization Basic or Bearer tokens, where X characters before or after token are kept. Default for the example is one character e.g. "x[...REDACTED...]x" to not accidentally leak too much of any token. This might be handy for certain reports if customer wants to review logs for evidences.

ATTENTION: This comes with an edge case. Picking any high number may result in the entire token being not redacted at all. So use of this should be done with caution and copied content always requires manual review before using in any report.